### PR TITLE
Updated the site manifest to enable PWA installation

### DIFF
--- a/src/favicons/site.webmanifest
+++ b/src/favicons/site.webmanifest
@@ -8,17 +8,23 @@
         {
             "src": "android-chrome-192x192.png",
             "sizes": "192x192",
-            "type": "image/png"
+            "type": "image/png",
+            "maskable": true,
+            "purpose": "any maskable"
         },
         {
             "src": "android-chrome-512x512.png",
             "sizes": "512x512",
-            "type": "image/png"
+            "type": "image/png",
+            "maskable": true,
+            "purpose": "any maskable"
         },
         {
             "src": "apple-touch-icon.png",
             "sizes": "180x180",
-            "type": "image/png"
+            "type": "image/png",
+            "maskable": true,
+            "purpose": "any maskable"
         },
         {
             "src": "apple-touch-icon-precomposed.png",
@@ -36,8 +42,9 @@
             "type": "image/png"
         }
     ],
+    "start_url": ".",
+    "display": "standalone",
     "orientation": "portrait-primary",
     "theme_color": "#ced4da",
-    "background_color": "#000191",
-    "display": "minimal-ui"
+    "background_color": "#000191"
 }


### PR DESCRIPTION
After looking at a Google Chrome Lighthouse report on this website, the only thing missing for this website to be used as a PWA is
- the `start_url` field in the site manifest JSON file
- Maskable icons

Here is a screenshot of the original Lighthouse report : 
![image](https://user-images.githubusercontent.com/5107774/116306923-f6fab500-a7a5-11eb-8aa8-41832525b02f.png)


The report was generates on https://media.interieur.gouv.fr/attestation-deplacement-derogatoire-covid-19/