### PR TITLE
Error parsing json_decode of quanrantine-pdf-data.json

### DIFF
--- a/src/quarantine-pdf-data.json
+++ b/src/quarantine-pdf-data.json
@@ -428,7 +428,7 @@
     "font": "LucioleBoldItalic",
     "size": "13",
     "label": "(dans un rayon défini par l'arrêté préfectoral)",
-    "group": 7,
+    "group": 7
   },
   {
     "type": "text",


### PR DESCRIPTION
Un virgule surnuméraire à la ligne 431 qui foire le parsing du pdf